### PR TITLE
Add transform hierarchy with BFS propagation

### DIFF
--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -6,14 +6,14 @@
 |-------|------|--------|-----------|--------|
 | 1 | Core Engine Foundation | Done | — | — |
 | 2 | Core Rendering & Scene | Done | — | — |
-| 3 | Entity & Scene Architecture | Planned | [Phase 3](https://github.com/Mere-Solace/Lance/milestone/1) | #1, #2 |
+| 3 | Entity & Scene Architecture | In Progress | [Phase 3](https://github.com/Mere-Solace/Lance/milestone/1) | #1, #2, #11, #12, #13, #14 |
 | 4 | Physics & Collision | Planned | [Phase 4](https://github.com/Mere-Solace/Lance/milestone/2) | #3, #4, #5 |
 | 5 | Weapons & Effects | Planned | [Phase 5](https://github.com/Mere-Solace/Lance/milestone/3) | #6, #7, #8, #9, #10 |
 
 ## Dependency Graph
 
 ```
-#1 ECS Architecture [P0] ───────┬──────────────────────────────────┐
+#1 ECS Architecture [P0] ✅ ────┬──────────────────────────────────┐
                                 │                                  │
 #2 Transform Hierarchy [P0] <───┤     #3 Physics System [P1] <──── ┤
         │                       │              │                   │
@@ -26,6 +26,13 @@
                                               #9 Bezier [P2] <────────────┘
                                                    │
                                          #10 Swing Effects [P3] <─── #7, #9
+
+#11 Text Rendering [P1] <── #1 ✅
+        │
+        ├── #12 Debug HUD [P2]
+        └── #13 Pause Screen [P2]
+
+#14 Demo Recording [P3] <── #1 ✅
 ```
 
 ## Architecture Principles

--- a/docs/roadmap/phases/phase-3-entity-architecture.md
+++ b/docs/roadmap/phases/phase-3-entity-architecture.md
@@ -4,8 +4,12 @@
 Introduce an ECS foundation using `hecs` and implement a transform hierarchy. This phase transitions Lance from direct struct composition to a proper entity-component architecture.
 
 ## Related Issues
-- [#1 ECS Architecture: Decide and Implement](https://github.com/Mere-Solace/Lance/issues/1) — P0, blocks everything
+- [#1 ECS Architecture: Decide and Implement](https://github.com/Mere-Solace/Lance/issues/1) — P0, blocks everything ✅
 - [#2 Transform Hierarchy / Anchor Points](https://github.com/Mere-Solace/Lance/issues/2) — P0, blocked by #1
+- [#11 Bitmap Font Text Rendering System](https://github.com/Mere-Solace/Lance/issues/11) — P1, blocks #12 and #13
+- [#12 Debug HUD: FPS and Camera Coordinates](https://github.com/Mere-Solace/Lance/issues/12) — P2, blocked by #11
+- [#13 Options/Pause Screen with Esc Key](https://github.com/Mere-Solace/Lance/issues/13) — P2, blocked by #11
+- [#14 Demo Recording System](https://github.com/Mere-Solace/Lance/issues/14) — P3, blocked by #1 (complete)
 
 ## Design Decisions
 - [ADR-001: ECS Architecture](../decisions/001-ecs-architecture.md) — hecs

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,16 +2,18 @@ mod camera;
 mod components;
 mod engine;
 mod renderer;
+mod systems;
 
 use camera::Camera;
-use components::{Color, Transform};
+use components::{add_child, Color, GlobalTransform, LocalTransform};
 use engine::input::InputState;
 use engine::time::FrameTimer;
 use engine::window::GameWindow;
-use glam::Vec3;
+use glam::{Mat4, Vec3};
 use hecs::World;
 use renderer::mesh::{create_ground_plane, create_sphere};
 use renderer::{MeshStore, Renderer};
+use systems::transform_propagation_system;
 
 fn main() {
     let sdl = sdl2::init().expect("Failed to init SDL2");
@@ -24,20 +26,34 @@ fn main() {
     let sphere_handle = meshes.add(create_sphere(1.0, 16, 32));
     let ground_handle = meshes.add(create_ground_plane(500.0));
 
-    // ECS world — scene objects are entities with Transform, MeshHandle, Color
+    // ECS world — scene objects are entities with LocalTransform, GlobalTransform, MeshHandle, Color
     let mut world = World::new();
 
     world.spawn((
-        Transform::new(Vec3::ZERO),
+        LocalTransform::new(Vec3::ZERO),
+        GlobalTransform(Mat4::IDENTITY),
         ground_handle,
         Color(Vec3::new(0.3, 0.6, 0.2)),
     ));
 
-    world.spawn((
-        Transform::new(Vec3::new(0.0, 2.0, 0.0)),
+    let red_sphere = world.spawn((
+        LocalTransform::new(Vec3::new(0.0, 2.0, 0.0)),
+        GlobalTransform(Mat4::IDENTITY),
         sphere_handle,
         Color(Vec3::new(0.8, 0.2, 0.15)),
     ));
+
+    // Test child: small blue sphere offset to the right of the red sphere
+    let mut child_transform = LocalTransform::new(Vec3::new(2.5, 0.0, 0.0));
+    child_transform.scale = Vec3::splat(0.4);
+    let child_sphere = world.spawn((
+        child_transform,
+        GlobalTransform(Mat4::IDENTITY),
+        sphere_handle,
+        Color(Vec3::new(0.2, 0.4, 0.9)),
+    ));
+
+    add_child(&mut world, red_sphere, child_sphere);
 
     sdl.mouse().set_relative_mouse_mode(true);
 
@@ -45,6 +61,7 @@ fn main() {
     let mut input = InputState::new();
     let mut timer = FrameTimer::new();
     let mut camera = Camera::new();
+    let mut time_accum: f32 = 0.0;
 
     loop {
         timer.tick();
@@ -56,6 +73,17 @@ fn main() {
 
         camera.look(input.mouse_dx, input.mouse_dy);
         camera.move_wasd(&input, timer.dt);
+
+        // Animate red sphere in a gentle circle for visual testing
+        time_accum += timer.dt;
+        if let Ok(mut local) = world.get::<&mut LocalTransform>(red_sphere) {
+            let t = time_accum * 0.5; // slow rotation
+            local.position.x = 4.0 * t.cos();
+            local.position.z = 4.0 * t.sin();
+        }
+
+        // Propagate transforms before rendering
+        transform_propagation_system(&mut world);
 
         let view = camera.view_matrix();
         let proj = camera.projection_matrix(window.aspect_ratio());

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -6,7 +6,7 @@ use hecs::World;
 use mesh::Mesh;
 use shader::ShaderProgram;
 
-use crate::components::{Color, MeshHandle, Transform};
+use crate::components::{Color, GlobalTransform, MeshHandle};
 
 const VERT_SRC: &str = include_str!("../../shaders/cel.vert");
 const FRAG_SRC: &str = include_str!("../../shaders/cel.frag");
@@ -74,11 +74,10 @@ impl Renderer {
         self.shader.set_float("u_fog_start", 50.0);
         self.shader.set_float("u_fog_end", 300.0);
 
-        for (_entity, (transform, mesh_handle, color)) in
-            world.query::<(&Transform, &MeshHandle, &Color)>().iter()
+        for (_entity, (global_transform, mesh_handle, color)) in
+            world.query::<(&GlobalTransform, &MeshHandle, &Color)>().iter()
         {
-            let model = transform.matrix();
-            self.shader.set_mat4("u_model", &model);
+            self.shader.set_mat4("u_model", &global_transform.0);
             self.shader.set_vec3("u_object_color", color.0);
             meshes.get(*mesh_handle).draw();
         }

--- a/src/systems/mod.rs
+++ b/src/systems/mod.rs
@@ -1,0 +1,3 @@
+mod transform;
+
+pub use transform::transform_propagation_system;

--- a/src/systems/transform.rs
+++ b/src/systems/transform.rs
@@ -1,0 +1,52 @@
+use std::collections::VecDeque;
+
+use glam::Mat4;
+use hecs::{Entity, World};
+
+use crate::components::{Children, GlobalTransform, LocalTransform, Parent};
+
+/// Propagates LocalTransform down the hierarchy via BFS.
+/// Roots (entities with LocalTransform but no Parent) compute GlobalTransform
+/// from their own LocalTransform. Children inherit parent's GlobalTransform
+/// multiplied by their own LocalTransform.
+pub fn transform_propagation_system(world: &mut World) {
+    let mut queue: VecDeque<(Entity, Mat4)> = VecDeque::new();
+
+    // Phase 1: update roots and seed BFS with their children
+    let roots: Vec<(Entity, Mat4)> = world
+        .query::<&LocalTransform>()
+        .without::<&Parent>()
+        .iter()
+        .map(|(entity, local)| (entity, local.matrix()))
+        .collect();
+
+    for (entity, global_mat) in &roots {
+        if let Ok(mut gt) = world.get::<&mut GlobalTransform>(*entity) {
+            gt.0 = *global_mat;
+        }
+        if let Ok(children) = world.get::<&Children>(*entity) {
+            for &child in &children.0 {
+                queue.push_back((child, *global_mat));
+            }
+        }
+    }
+
+    // Phase 2: BFS propagation
+    while let Some((entity, parent_global)) = queue.pop_front() {
+        let child_global = if let Ok(local) = world.get::<&LocalTransform>(entity) {
+            parent_global * local.matrix()
+        } else {
+            parent_global
+        };
+
+        if let Ok(mut gt) = world.get::<&mut GlobalTransform>(entity) {
+            gt.0 = child_global;
+        }
+
+        if let Ok(children) = world.get::<&Children>(entity) {
+            for &child in &children.0 {
+                queue.push_back((child, child_global));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Rename `Transform` → `LocalTransform`, add `GlobalTransform(Mat4)`, `Parent(Entity)`, `Children(Vec<Entity>)` components with `add_child`/`remove_child` helpers
- Implement flat BFS transform propagation system in `src/systems/transform.rs`
- Renderer queries `GlobalTransform` instead of computing matrices inline
- Test child sphere (small blue) parented to animated red sphere for visual verification

Closes #2

## Test plan
- [x] `build.bat` compiles cleanly with no warnings
- [x] Run exe: ground plane, red sphere orbiting in a circle, small blue child sphere follows it
- [x] Child sphere maintains correct offset from parent as parent moves