### PR TITLE
Add player entity with capsule body and camera modes

### DIFF
--- a/src/camera.rs
+++ b/src/camera.rs
@@ -3,6 +3,12 @@ use sdl2::keyboard::Scancode;
 
 use crate::engine::input::InputState;
 
+#[derive(PartialEq, Eq)]
+pub enum CameraMode {
+    Player,
+    Fly,
+}
+
 pub struct Camera {
     pub position: Vec3,
     pub yaw: f32,
@@ -10,6 +16,8 @@ pub struct Camera {
     pub speed: f32,
     pub sensitivity: f32,
     pub fov: f32,
+    pub mode: CameraMode,
+    pub third_person: bool,
 }
 
 impl Camera {
@@ -21,6 +29,30 @@ impl Camera {
             speed: 5.0,
             sensitivity: 0.1,
             fov: 45.0,
+            mode: CameraMode::Player,
+            third_person: true,
+        }
+    }
+
+    pub fn toggle_mode(&mut self) {
+        self.mode = match self.mode {
+            CameraMode::Player => CameraMode::Fly,
+            CameraMode::Fly => CameraMode::Player,
+        };
+    }
+
+    pub fn toggle_perspective(&mut self) {
+        self.third_person = !self.third_person;
+    }
+
+    pub fn follow_player(&mut self, player_pos: Vec3, eye_height: f32) {
+        let eye_pos = player_pos + Vec3::Y * eye_height;
+        if self.third_person {
+            // Place camera behind and above the player
+            let back = -self.front();
+            self.position = eye_pos + back * 3.0 + Vec3::Y * 0.5;
+        } else {
+            self.position = eye_pos;
         }
     }
 

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -97,3 +97,9 @@ pub struct MeshHandle(pub usize);
 
 /// RGB color applied to an entity for rendering.
 pub struct Color(pub Vec3);
+
+/// Marker: this entity is the player.
+pub struct Player;
+
+/// Marker: entity is touching the ground (set each physics frame).
+pub struct Grounded;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,19 +4,20 @@ mod engine;
 mod renderer;
 mod systems;
 
-use camera::Camera;
+use camera::{Camera, CameraMode};
 use components::{
-    add_child, Collider, Color, GlobalTransform, GravityAffected, LocalTransform, Mass,
-    Restitution, Static, Velocity,
+    add_child, Collider, Color, GlobalTransform, GravityAffected, Grounded, LocalTransform, Mass,
+    Player, Restitution, Static, Velocity,
 };
-use engine::input::InputState;
+use engine::input::{InputEvent, InputState};
 use engine::time::FrameTimer;
 use engine::window::GameWindow;
 use glam::{Mat4, Vec3};
 use hecs::World;
-use renderer::mesh::{create_ground_plane, create_sphere};
+use renderer::mesh::{create_capsule, create_ground_plane, create_sphere};
 use renderer::{MeshStore, Renderer};
-use systems::{physics_system, transform_propagation_system};
+use sdl2::keyboard::Scancode;
+use systems::{grounded_system, physics_system, player_movement_system, transform_propagation_system};
 
 fn main() {
     let sdl = sdl2::init().expect("Failed to init SDL2");
@@ -28,6 +29,7 @@ fn main() {
     let mut meshes = MeshStore::new();
     let sphere_handle = meshes.add(create_sphere(1.0, 16, 32));
     let ground_handle = meshes.add(create_ground_plane(500.0));
+    let capsule_handle = meshes.add(create_capsule(0.3, 1.0, 16, 16));
 
     // ECS world — scene objects are entities with LocalTransform, GlobalTransform, MeshHandle, Color
     let mut world = World::new();
@@ -68,6 +70,24 @@ fn main() {
 
     add_child(&mut world, red_sphere, child_sphere);
 
+    // Player entity — capsule body with physics
+    let player_entity = world.spawn((
+        LocalTransform::new(Vec3::new(0.0, 2.0, -5.0)),
+        GlobalTransform(Mat4::IDENTITY),
+        capsule_handle,
+        Color(Vec3::new(0.6, 0.6, 0.7)),
+        Velocity(Vec3::ZERO),
+        Mass(80.0),
+        GravityAffected,
+        Collider::Capsule {
+            radius: 0.3,
+            height: 1.0,
+        },
+        Restitution(0.0),
+        Player,
+        Grounded,
+    ));
+
     sdl.mouse().set_relative_mouse_mode(true);
 
     let mut event_pump = sdl.event_pump().expect("Failed to get event pump");
@@ -84,10 +104,34 @@ fn main() {
             break;
         }
 
-        camera.look(input.mouse_dx, input.mouse_dy);
-        camera.move_wasd(&input, timer.dt);
+        // F1 toggles fly/player mode, Z toggles first/third person
+        for event in &input.events {
+            match event {
+                InputEvent::KeyPressed(Scancode::F1) => camera.toggle_mode(),
+                InputEvent::KeyPressed(Scancode::Z) => camera.toggle_perspective(),
+                _ => {}
+            }
+        }
 
-        physics_system(&mut world, &mut physics_accum, timer.dt);
+        camera.look(input.mouse_dx, input.mouse_dy);
+
+        match camera.mode {
+            CameraMode::Player => {
+                player_movement_system(&mut world, &input, &camera);
+            }
+            CameraMode::Fly => {
+                camera.move_wasd(&input, timer.dt);
+            }
+        }
+
+        let collision_events = physics_system(&mut world, &mut physics_accum, timer.dt);
+        grounded_system(&mut world, &collision_events);
+
+        if camera.mode == CameraMode::Player {
+            if let Ok(local) = world.get::<&LocalTransform>(player_entity) {
+                camera.follow_player(local.position, 0.7);
+            }
+        }
 
         // Propagate transforms before rendering
         transform_propagation_system(&mut world);

--- a/src/renderer/mesh.rs
+++ b/src/renderer/mesh.rs
@@ -133,6 +133,84 @@ pub fn create_sphere(radius: f32, stacks: u32, sectors: u32) -> Mesh {
     upload_mesh(&vertices, &indices)
 }
 
+pub fn create_capsule(radius: f32, height: f32, sectors: u32, stacks: u32) -> Mesh {
+    let mut vertices = Vec::new();
+    let mut indices = Vec::new();
+
+    let half_height = height * 0.5;
+    let half_stacks = stacks / 2;
+
+    // Top hemisphere (offset up by half_height)
+    for i in 0..=half_stacks {
+        let stack_angle = PI / 2.0 - (i as f32) * (PI / 2.0) / (half_stacks as f32);
+        let xy = radius * stack_angle.cos();
+        let y = radius * stack_angle.sin() + half_height;
+
+        for j in 0..=sectors {
+            let sector_angle = 2.0 * PI * (j as f32) / (sectors as f32);
+            let x = xy * sector_angle.cos();
+            let z = xy * sector_angle.sin();
+
+            vertices.push(x);
+            vertices.push(y);
+            vertices.push(z);
+
+            let nx = stack_angle.cos() * sector_angle.cos();
+            let ny = stack_angle.sin();
+            let nz = stack_angle.cos() * sector_angle.sin();
+            vertices.push(nx);
+            vertices.push(ny);
+            vertices.push(nz);
+        }
+    }
+
+    let top_rows = half_stacks + 1;
+
+    // Bottom hemisphere (offset down by half_height)
+    for i in 0..=half_stacks {
+        let stack_angle = -(i as f32) * (PI / 2.0) / (half_stacks as f32);
+        let xy = radius * stack_angle.cos();
+        let y = radius * stack_angle.sin() - half_height;
+
+        for j in 0..=sectors {
+            let sector_angle = 2.0 * PI * (j as f32) / (sectors as f32);
+            let x = xy * sector_angle.cos();
+            let z = xy * sector_angle.sin();
+
+            vertices.push(x);
+            vertices.push(y);
+            vertices.push(z);
+
+            let nx = stack_angle.cos() * sector_angle.cos();
+            let ny = stack_angle.sin();
+            let nz = stack_angle.cos() * sector_angle.sin();
+            vertices.push(nx);
+            vertices.push(ny);
+            vertices.push(nz);
+        }
+    }
+
+    let total_rows = top_rows + half_stacks + 1;
+
+    // Generate indices for all rows
+    for i in 0..(total_rows - 1) {
+        for j in 0..sectors {
+            let first = i * (sectors + 1) + j;
+            let second = first + sectors + 1;
+
+            indices.push(first);
+            indices.push(second);
+            indices.push(first + 1);
+
+            indices.push(first + 1);
+            indices.push(second);
+            indices.push(second + 1);
+        }
+    }
+
+    upload_mesh(&vertices, &indices)
+}
+
 pub fn create_ground_plane(half_extent: f32) -> Mesh {
     let h = half_extent;
     #[rustfmt::skip]

--- a/src/systems/mod.rs
+++ b/src/systems/mod.rs
@@ -1,6 +1,8 @@
 mod collision;
 mod physics;
+mod player;
 mod transform;
 
 pub use physics::physics_system;
+pub use player::{grounded_system, player_movement_system};
 pub use transform::transform_propagation_system;

--- a/src/systems/physics.rs
+++ b/src/systems/physics.rs
@@ -1,14 +1,15 @@
 use glam::Vec3;
 use hecs::World;
 
-use crate::components::{Acceleration, GravityAffected, LocalTransform, Velocity};
+use crate::components::{Acceleration, CollisionEvent, GravityAffected, LocalTransform, Velocity};
 use super::collision::collision_system;
 
 const PHYSICS_DT: f32 = 1.0 / 60.0;
 const GRAVITY: Vec3 = Vec3::new(0.0, -9.81, 0.0);
 
-pub fn physics_system(world: &mut World, accumulator: &mut f32, frame_dt: f32) {
+pub fn physics_system(world: &mut World, accumulator: &mut f32, frame_dt: f32) -> Vec<CollisionEvent> {
     *accumulator += frame_dt;
+    let mut all_events = Vec::new();
 
     while *accumulator >= PHYSICS_DT {
         // 1. Integrate velocity + position
@@ -31,8 +32,11 @@ pub fn physics_system(world: &mut World, accumulator: &mut f32, frame_dt: f32) {
         }
 
         // 2. Detect & resolve collisions
-        let _events = collision_system(world);
+        let events = collision_system(world);
+        all_events.extend(events);
 
         *accumulator -= PHYSICS_DT;
     }
+
+    all_events
 }

--- a/src/systems/player.rs
+++ b/src/systems/player.rs
@@ -1,0 +1,79 @@
+use glam::Vec3;
+use hecs::World;
+use sdl2::keyboard::Scancode;
+
+use crate::camera::Camera;
+use crate::components::{CollisionEvent, Grounded, Player, Velocity};
+use crate::engine::input::InputState;
+
+const PLAYER_MOVE_SPEED: f32 = 6.0;
+const JUMP_IMPULSE: f32 = 7.0;
+
+pub fn player_movement_system(world: &mut World, input: &InputState, camera: &Camera) {
+    let yaw_rad = camera.yaw.to_radians();
+    let forward = Vec3::new(yaw_rad.cos(), 0.0, yaw_rad.sin()).normalize();
+    let right = forward.cross(Vec3::Y).normalize();
+
+    let mut move_dir = Vec3::ZERO;
+    if input.is_key_held(Scancode::W) {
+        move_dir += forward;
+    }
+    if input.is_key_held(Scancode::S) {
+        move_dir -= forward;
+    }
+    if input.is_key_held(Scancode::A) {
+        move_dir -= right;
+    }
+    if input.is_key_held(Scancode::D) {
+        move_dir += right;
+    }
+
+    let horizontal = if move_dir.length_squared() > 0.0 {
+        move_dir.normalize() * PLAYER_MOVE_SPEED
+    } else {
+        Vec3::ZERO
+    };
+
+    for (_entity, (vel, _player, grounded)) in
+        world.query_mut::<(&mut Velocity, &Player, Option<&Grounded>)>()
+    {
+        vel.0.x = horizontal.x;
+        vel.0.z = horizontal.z;
+
+        if grounded.is_some() && input.is_key_held(Scancode::Space) {
+            vel.0.y = JUMP_IMPULSE;
+        }
+    }
+}
+
+pub fn grounded_system(world: &mut World, events: &[CollisionEvent]) {
+    // Remove Grounded from all player entities
+    let players: Vec<_> = world
+        .query_mut::<(&Player, &Grounded)>()
+        .into_iter()
+        .map(|(e, _)| e)
+        .collect();
+    for entity in players {
+        let _ = world.remove_one::<Grounded>(entity);
+    }
+
+    // Check collision events for ground contacts
+    for event in events {
+        // Normal points A→B. Push direction for A is -normal, for B is +normal.
+        let a_is_player = world.get::<&Player>(event.entity_a).is_ok();
+        let b_is_player = world.get::<&Player>(event.entity_b).is_ok();
+
+        if a_is_player {
+            let push_dir = -event.contact_normal;
+            if push_dir.dot(Vec3::Y) > 0.7 {
+                let _ = world.insert_one(event.entity_a, Grounded);
+            }
+        }
+        if b_is_player {
+            let push_dir = event.contact_normal;
+            if push_dir.dot(Vec3::Y) > 0.7 {
+                let _ = world.insert_one(event.entity_b, Grounded);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Replace free-flying camera with a physics-driven first-person player entity (capsule collider, gravity, WASD movement, Space to jump)
- Add third-person camera mode (Z toggle) that orbits behind the player, and fly-cam debug mode (F1 toggle)
- Wire collision events out of `physics_system` to drive a new `grounded_system` for jump detection

## Changes
- **`src/components/mod.rs`** — `Player` and `Grounded` marker components
- **`src/renderer/mesh.rs`** — `create_capsule()` mesh generator (top/bottom hemispheres with seamless indices)
- **`src/camera.rs`** — `CameraMode` enum (Player/Fly), `third_person` toggle, `follow_player()` with first/third person positioning
- **`src/systems/player.rs`** *(new)* — `player_movement_system` (horizontal WASD at 6 m/s, jump impulse 7.0) and `grounded_system` (collision normal dot check)
- **`src/systems/physics.rs`** — `physics_system` now returns `Vec<CollisionEvent>`
- **`src/main.rs`** — Spawn player entity, F1/Z key handling, rewired loop order with camera follow

## Test plan
- [x] Player spawns, falls to ground, WASD moves along ground, Space jumps
- [x] F1 switches to free-flying debug camera, F1 again returns to player mode
- [x] Z toggles between first-person and third-person view
- [x] Third-person camera sits behind and above the player capsule
- [x] Player collides with ground plane and doesn't fall through
- [x] Red sphere and child sphere still bounce and follow as before

Closes #5