### PR TITLE
Add checkerboard pattern to ground plane

### DIFF
--- a/shaders/cel.frag
+++ b/shaders/cel.frag
@@ -5,11 +5,13 @@ in vec3 v_normal;
 
 uniform vec3 u_light_dir;
 uniform vec3 u_object_color;
+uniform vec3 u_object_color_2;
 uniform vec3 u_ambient_color;
 uniform vec3 u_camera_pos;
 uniform vec3 u_fog_color;
 uniform float u_fog_start;
 uniform float u_fog_end;
+uniform int u_checkerboard;
 
 out vec4 frag_color;
 
@@ -30,7 +32,14 @@ void main() {
         intensity = 0.2;
     }
 
-    vec3 lit_color = u_object_color * (u_ambient_color + vec3(intensity));
+    // Checkerboard pattern using world XZ coordinates
+    vec3 base_color = u_object_color;
+    if (u_checkerboard != 0) {
+        float checker = mod(floor(v_world_pos.x) + floor(v_world_pos.z), 2.0);
+        base_color = mix(u_object_color, u_object_color_2, checker);
+    }
+
+    vec3 lit_color = base_color * (u_ambient_color + vec3(intensity));
 
     // Linear depth fog
     float dist = length(v_world_pos - u_camera_pos);

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -111,3 +111,6 @@ pub struct Player;
 
 /// Marker: entity is touching the ground (set each physics frame).
 pub struct Grounded;
+
+/// Checkerboard pattern using primary Color and this secondary color.
+pub struct Checkerboard(pub Vec3);

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,8 +6,8 @@ mod systems;
 
 use camera::{Camera, CameraMode};
 use components::{
-    add_child, Collider, Color, Drag, Friction, GlobalTransform, GravityAffected, Grounded,
-    LocalTransform, Mass, Player, Restitution, Static, Velocity,
+    add_child, Checkerboard, Collider, Color, Drag, Friction, GlobalTransform, GravityAffected,
+    Grounded, LocalTransform, Mass, Player, Restitution, Static, Velocity,
 };
 use engine::input::{InputEvent, InputState};
 use engine::time::FrameTimer;
@@ -39,6 +39,7 @@ fn main() {
         GlobalTransform(Mat4::IDENTITY),
         ground_handle,
         Color(Vec3::new(0.3, 0.6, 0.2)),
+        Checkerboard(Vec3::new(0.22, 0.48, 0.15)),
         Collider::Plane {
             normal: Vec3::Y,
             offset: 0.0,

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -6,7 +6,7 @@ use hecs::World;
 use mesh::Mesh;
 use shader::ShaderProgram;
 
-use crate::components::{Color, GlobalTransform, MeshHandle};
+use crate::components::{Checkerboard, Color, GlobalTransform, MeshHandle};
 
 const VERT_SRC: &str = include_str!("../../shaders/cel.vert");
 const FRAG_SRC: &str = include_str!("../../shaders/cel.frag");
@@ -74,11 +74,17 @@ impl Renderer {
         self.shader.set_float("u_fog_start", 50.0);
         self.shader.set_float("u_fog_end", 300.0);
 
-        for (_entity, (global_transform, mesh_handle, color)) in
-            world.query::<(&GlobalTransform, &MeshHandle, &Color)>().iter()
+        for (_entity, (global_transform, mesh_handle, color, checker)) in
+            world.query::<(&GlobalTransform, &MeshHandle, &Color, Option<&Checkerboard>)>().iter()
         {
             self.shader.set_mat4("u_model", &global_transform.0);
             self.shader.set_vec3("u_object_color", color.0);
+            if let Some(checker) = checker {
+                self.shader.set_int("u_checkerboard", 1);
+                self.shader.set_vec3("u_object_color_2", checker.0);
+            } else {
+                self.shader.set_int("u_checkerboard", 0);
+            }
             meshes.get(*mesh_handle).draw();
         }
     }

--- a/src/renderer/shader.rs
+++ b/src/renderer/shader.rs
@@ -81,6 +81,13 @@ impl ShaderProgram {
             gl::Uniform1f(loc, val);
         }
     }
+
+    pub fn set_int(&mut self, name: &str, val: i32) {
+        let loc = self.get_uniform_location(name);
+        unsafe {
+            gl::Uniform1i(loc, val);
+        }
+    }
 }
 
 impl Drop for ShaderProgram {


### PR DESCRIPTION
## Summary
- Add `Checkerboard(Vec3)` component that holds a secondary color
- Fragment shader alternates between primary and secondary color based on world XZ coordinates
- Ground uses mid green (0.3, 0.6, 0.2) and darker green (0.22, 0.48, 0.15)

## Test plan
- [ ] Run engine, verify ground displays a two-tone green checkerboard pattern
- [ ] Verify non-checkerboard entities (spheres, player capsule) render normally