### PR TITLE
Add raycast grab/throw system

### DIFF
--- a/src/camera.rs
+++ b/src/camera.rs
@@ -45,14 +45,15 @@ impl Camera {
         self.third_person = !self.third_person;
     }
 
-    pub fn follow_player(&mut self, player_pos: Vec3, eye_height: f32) {
+    pub fn follow_player(&mut self, player_pos: Vec3, eye_height: f32, capsule_radius: f32) {
         let eye_pos = player_pos + Vec3::Y * eye_height;
         if self.third_person {
             // Place camera behind and above the player
             let back = -self.front();
             self.position = eye_pos + back * 3.0 + Vec3::Y * 0.5;
         } else {
-            self.position = eye_pos;
+            // Place camera just in front of capsule face to avoid clipping
+            self.position = eye_pos + self.front() * capsule_radius;
         }
     }
 

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -114,3 +114,32 @@ pub struct Grounded;
 
 /// Checkerboard pattern using primary Color and this secondary color.
 pub struct Checkerboard(pub Vec3);
+
+/// Marker: entity is hidden from rendering but still participates in physics/collision.
+pub struct Hidden;
+
+/// Marker: entity can be grabbed by the player.
+pub struct Grabbable;
+
+/// Marker: entity is currently held (skip physics/collision).
+pub struct Held;
+
+/// State for the grab/throw system, attached to the player entity.
+pub struct GrabState {
+    pub held_entity: Option<Entity>,
+    pub wind_up_time: f32,
+    pub is_winding: bool,
+    /// World-space rotation of the held entity at grab time (preserved while held).
+    pub held_rotation: Quat,
+}
+
+impl GrabState {
+    pub fn new() -> Self {
+        Self {
+            held_entity: None,
+            wind_up_time: 0.0,
+            is_winding: false,
+            held_rotation: Quat::IDENTITY,
+        }
+    }
+}

--- a/src/engine/input.rs
+++ b/src/engine/input.rs
@@ -1,5 +1,6 @@
 use sdl2::event::Event;
 use sdl2::keyboard::Scancode;
+use sdl2::mouse::MouseButton;
 use sdl2::EventPump;
 use std::collections::HashSet;
 
@@ -7,12 +8,15 @@ use std::collections::HashSet;
 pub enum InputEvent {
     KeyPressed(Scancode),
     KeyReleased(Scancode),
+    MouseButtonPressed(MouseButton),
+    MouseButtonReleased(MouseButton),
     MouseMotion { dx: f32, dy: f32 },
     Quit,
 }
 
 pub struct InputState {
     pub keys: HashSet<Scancode>,
+    pub mouse_buttons: HashSet<MouseButton>,
     pub mouse_dx: f32,
     pub mouse_dy: f32,
     pub events: Vec<InputEvent>,
@@ -22,6 +26,7 @@ impl InputState {
     pub fn new() -> Self {
         Self {
             keys: HashSet::new(),
+            mouse_buttons: HashSet::new(),
             mouse_dx: 0.0,
             mouse_dy: 0.0,
             events: Vec::new(),
@@ -51,6 +56,15 @@ impl InputState {
                     self.keys.remove(&sc);
                     self.events.push(InputEvent::KeyReleased(sc));
                 }
+                Event::MouseButtonDown { mouse_btn, .. } => {
+                    if self.mouse_buttons.insert(mouse_btn) {
+                        self.events.push(InputEvent::MouseButtonPressed(mouse_btn));
+                    }
+                }
+                Event::MouseButtonUp { mouse_btn, .. } => {
+                    self.mouse_buttons.remove(&mouse_btn);
+                    self.events.push(InputEvent::MouseButtonReleased(mouse_btn));
+                }
                 Event::MouseMotion { xrel, yrel, .. } => {
                     let dx = xrel as f32;
                     let dy = yrel as f32;
@@ -65,6 +79,10 @@ impl InputState {
 
     pub fn is_key_held(&self, sc: Scancode) -> bool {
         self.keys.contains(&sc)
+    }
+
+    pub fn is_mouse_button_held(&self, btn: MouseButton) -> bool {
+        self.mouse_buttons.contains(&btn)
     }
 
     pub fn should_quit(&self) -> bool {

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -6,7 +6,7 @@ use hecs::World;
 use mesh::Mesh;
 use shader::ShaderProgram;
 
-use crate::components::{Checkerboard, Color, GlobalTransform, MeshHandle};
+use crate::components::{Checkerboard, Color, GlobalTransform, Hidden, MeshHandle};
 
 const VERT_SRC: &str = include_str!("../../shaders/cel.vert");
 const FRAG_SRC: &str = include_str!("../../shaders/cel.frag");
@@ -74,9 +74,12 @@ impl Renderer {
         self.shader.set_float("u_fog_start", 50.0);
         self.shader.set_float("u_fog_end", 300.0);
 
-        for (_entity, (global_transform, mesh_handle, color, checker)) in
-            world.query::<(&GlobalTransform, &MeshHandle, &Color, Option<&Checkerboard>)>().iter()
+        for (_entity, (global_transform, mesh_handle, color, checker, hidden)) in
+            world.query::<(&GlobalTransform, &MeshHandle, &Color, Option<&Checkerboard>, Option<&Hidden>)>().iter()
         {
+            if hidden.is_some() {
+                continue;
+            }
             self.shader.set_mat4("u_model", &global_transform.0);
             self.shader.set_vec3("u_object_color", color.0);
             if let Some(checker) = checker {

--- a/src/systems/collision.rs
+++ b/src/systems/collision.rs
@@ -1,7 +1,7 @@
 use glam::Vec3;
 use hecs::{Entity, World};
 
-use crate::components::{Collider, CollisionEvent, Friction, LocalTransform, Restitution, Static, Velocity};
+use crate::components::{Collider, CollisionEvent, Friction, Held, LocalTransform, Restitution, Static, Velocity};
 
 struct ColliderEntry {
     entity: Entity,
@@ -188,9 +188,10 @@ fn apply_friction(vel: &mut Vec3, normal: Vec3, mu: f32, normal_impulse: f32) {
 pub fn collision_system(world: &mut World) -> Vec<CollisionEvent> {
     // Gather all collider entries
     let entries: Vec<ColliderEntry> = world
-        .query_mut::<(&LocalTransform, &Collider)>()
+        .query_mut::<(&LocalTransform, &Collider, Option<&Held>)>()
         .into_iter()
-        .map(|(entity, (local, collider))| {
+        .filter(|(_entity, (_local, _collider, held))| held.is_none())
+        .map(|(entity, (local, collider, _held))| {
             let kind = match collider {
                 Collider::Sphere { radius } => ColliderKind::Sphere { radius: *radius },
                 Collider::Capsule { radius, height } => ColliderKind::Capsule {

--- a/src/systems/grab.rs
+++ b/src/systems/grab.rs
@@ -1,0 +1,219 @@
+use glam::{Quat, Vec3};
+use hecs::World;
+use sdl2::keyboard::Scancode;
+use sdl2::mouse::MouseButton;
+
+use crate::camera::Camera;
+use crate::components::{
+    add_child, remove_child, GlobalTransform, GrabState, Grabbable, Held, LocalTransform, Player,
+    Static, Velocity,
+};
+use crate::engine::input::{InputEvent, InputState};
+
+use super::raycast::raycast_grabbable;
+
+const GRAB_DISTANCE: f32 = 5.0;
+const HOLD_OFFSET: Vec3 = Vec3::new(0.0, 0.5, 1.5);
+const HOLD_LERP_SPEED: f32 = 10.0;
+const MIN_THROW_FORCE: f32 = 5.0;
+const MAX_THROW_FORCE: f32 = 20.0;
+const MAX_WIND_UP_TIME: f32 = 0.75;
+const WIND_UP_MOVE_SLOWDOWN: f32 = 0.3;
+
+/// Grab/throw system. Returns movement speed multiplier (1.0 normal, 0.3 during wind-up).
+pub fn grab_throw_system(
+    world: &mut World,
+    input: &InputState,
+    camera: &Camera,
+    dt: f32,
+) -> f32 {
+    // Get player's GrabState and entity
+    let player_entity = {
+        let mut found = None;
+        for (entity, (_player, _grab)) in world.query::<(&Player, &GrabState)>().iter() {
+            found = Some(entity);
+            break;
+        }
+        match found {
+            Some(e) => e,
+            None => return 1.0,
+        }
+    };
+
+    // Check for right-click pressed event (grab trigger: Alt + RightClick)
+    let right_click_pressed = input.events.iter().any(|e| {
+        matches!(e, InputEvent::MouseButtonPressed(MouseButton::Right))
+    });
+    let left_click_released = input.events.iter().any(|e| {
+        matches!(e, InputEvent::MouseButtonReleased(MouseButton::Left))
+    });
+    let alt_held = input.is_key_held(Scancode::LAlt) || input.is_key_held(Scancode::RAlt);
+    let right_held = input.is_mouse_button_held(MouseButton::Right);
+    let left_held = input.is_mouse_button_held(MouseButton::Left);
+
+    // Read current grab state
+    let (held_entity, is_winding, wind_up_time, held_rotation) = {
+        let grab = world.get::<&GrabState>(player_entity).unwrap();
+        (grab.held_entity, grab.is_winding, grab.wind_up_time, grab.held_rotation)
+    };
+
+    match held_entity {
+        None => {
+            // Not holding — check for grab attempt
+            if right_click_pressed && alt_held {
+                if let Some(hit) = raycast_grabbable(world, camera.position, camera.front(), GRAB_DISTANCE) {
+                    // Don't grab static entities
+                    if world.get::<&Static>(hit.entity).is_ok() {
+                        return 1.0;
+                    }
+                    // Don't grab non-Grabbable (redundant since raycast filters, but safe)
+                    if world.get::<&Grabbable>(hit.entity).is_err() {
+                        return 1.0;
+                    }
+
+                    // Read player's world position and rotation for coordinate conversion
+                    let (player_pos, player_yaw) = {
+                        let lt = world.get::<&LocalTransform>(player_entity).unwrap();
+                        (lt.position, lt.rotation)
+                    };
+
+                    // Read held entity's world position and rotation
+                    let (held_world_pos, held_world_rot) = {
+                        let lt = world.get::<&LocalTransform>(hit.entity).unwrap();
+                        (lt.position, lt.rotation)
+                    };
+
+                    // Compute local offset relative to player
+                    let world_offset = held_world_pos - player_pos;
+                    let inv_yaw = player_yaw.inverse();
+                    let local_offset = inv_yaw * world_offset;
+
+                    // Re-parent held entity under player
+                    add_child(world, player_entity, hit.entity);
+
+                    // Set local transform: counter-rotate to preserve world orientation
+                    if let Ok(mut lt) = world.get::<&mut LocalTransform>(hit.entity) {
+                        lt.position = local_offset;
+                        lt.rotation = inv_yaw * held_world_rot;
+                    }
+
+                    // Mark as held, store the world rotation to preserve it
+                    let _ = world.insert_one(hit.entity, Held);
+                    let mut grab = world.get::<&mut GrabState>(player_entity).unwrap();
+                    grab.held_entity = Some(hit.entity);
+                    grab.held_rotation = held_world_rot;
+                    grab.wind_up_time = 0.0;
+                    grab.is_winding = false;
+                }
+            }
+            1.0
+        }
+        Some(held) => {
+            // Safety: check entity still exists
+            if !world.contains(held) {
+                let mut grab = world.get::<&mut GrabState>(player_entity).unwrap();
+                grab.held_entity = None;
+                grab.wind_up_time = 0.0;
+                grab.is_winding = false;
+                return 1.0;
+            }
+
+            // Drop when either Alt OR right-click is released (and not winding)
+            let should_drop = (!alt_held || !right_held) && !is_winding;
+
+            if should_drop {
+                // Read world position from GlobalTransform before un-parenting
+                let world_pos = world
+                    .get::<&GlobalTransform>(held)
+                    .map(|gt| {
+                        let cols = gt.0.to_cols_array_2d();
+                        Vec3::new(cols[3][0], cols[3][1], cols[3][2])
+                    })
+                    .unwrap_or_else(|_| {
+                        world.get::<&LocalTransform>(held).map(|lt| lt.position).unwrap_or(Vec3::ZERO)
+                    });
+
+                // Un-parent from player
+                remove_child(world, player_entity, held);
+
+                // Set world position and zero velocity
+                if let Ok(mut lt) = world.get::<&mut LocalTransform>(held) {
+                    lt.position = world_pos;
+                    lt.rotation = Quat::IDENTITY;
+                }
+                let _ = world.remove_one::<Held>(held);
+                if let Ok(mut vel) = world.get::<&mut Velocity>(held) {
+                    vel.0 = Vec3::ZERO;
+                }
+                let mut grab = world.get::<&mut GrabState>(player_entity).unwrap();
+                grab.held_entity = None;
+                grab.wind_up_time = 0.0;
+                grab.is_winding = false;
+                return 1.0;
+            }
+
+            // Lerp local position toward hold offset (player-relative)
+            // Counter-rotate to preserve the object's world orientation from grab time
+            let player_rot = world
+                .get::<&LocalTransform>(player_entity)
+                .map(|lt| lt.rotation)
+                .unwrap_or(Quat::IDENTITY);
+            if let Ok(mut lt) = world.get::<&mut LocalTransform>(held) {
+                let diff = HOLD_OFFSET - lt.position;
+                lt.position += diff * (HOLD_LERP_SPEED * dt).min(1.0);
+                lt.rotation = player_rot.inverse() * held_rotation;
+            }
+            // Zero velocity while held
+            if let Ok(mut vel) = world.get::<&mut Velocity>(held) {
+                vel.0 = Vec3::ZERO;
+            }
+
+            // Wind-up with left click
+            if left_held {
+                let mut grab = world.get::<&mut GrabState>(player_entity).unwrap();
+                grab.is_winding = true;
+                grab.wind_up_time = (grab.wind_up_time + dt).min(MAX_WIND_UP_TIME);
+                return WIND_UP_MOVE_SLOWDOWN;
+            }
+
+            // Throw on left click release while winding
+            if left_click_released && is_winding {
+                let throw_t = (wind_up_time / MAX_WIND_UP_TIME).clamp(0.0, 1.0);
+                let force = MIN_THROW_FORCE + (MAX_THROW_FORCE - MIN_THROW_FORCE) * throw_t;
+                let throw_vel = camera.front() * force;
+
+                // Read world position from GlobalTransform before un-parenting
+                let world_pos = world
+                    .get::<&GlobalTransform>(held)
+                    .map(|gt| {
+                        let cols = gt.0.to_cols_array_2d();
+                        Vec3::new(cols[3][0], cols[3][1], cols[3][2])
+                    })
+                    .unwrap_or_else(|_| {
+                        world.get::<&LocalTransform>(held).map(|lt| lt.position).unwrap_or(Vec3::ZERO)
+                    });
+
+                // Un-parent from player
+                remove_child(world, player_entity, held);
+
+                // Set world position and throw velocity
+                if let Ok(mut lt) = world.get::<&mut LocalTransform>(held) {
+                    lt.position = world_pos;
+                    lt.rotation = Quat::IDENTITY;
+                }
+                let _ = world.remove_one::<Held>(held);
+                if let Ok(mut vel) = world.get::<&mut Velocity>(held) {
+                    vel.0 = throw_vel;
+                }
+                let mut grab = world.get::<&mut GrabState>(player_entity).unwrap();
+                grab.held_entity = None;
+                grab.wind_up_time = 0.0;
+                grab.is_winding = false;
+                return 1.0;
+            }
+
+            // Still holding, not winding
+            1.0
+        }
+    }
+}

--- a/src/systems/mod.rs
+++ b/src/systems/mod.rs
@@ -1,8 +1,11 @@
 mod collision;
+mod grab;
 mod physics;
 mod player;
+mod raycast;
 mod transform;
 
+pub use grab::grab_throw_system;
 pub use physics::physics_system;
 pub use player::{grounded_system, player_movement_system};
 pub use transform::transform_propagation_system;

--- a/src/systems/physics.rs
+++ b/src/systems/physics.rs
@@ -1,7 +1,7 @@
 use glam::Vec3;
 use hecs::World;
 
-use crate::components::{Acceleration, CollisionEvent, Drag, GravityAffected, LocalTransform, Velocity};
+use crate::components::{Acceleration, CollisionEvent, Drag, GravityAffected, Held, LocalTransform, Velocity};
 use super::collision::collision_system;
 
 const PHYSICS_DT: f32 = 1.0 / 60.0;
@@ -13,15 +13,19 @@ pub fn physics_system(world: &mut World, accumulator: &mut f32, frame_dt: f32) -
 
     while *accumulator >= PHYSICS_DT {
         // 1. Integrate velocity + position
-        for (_entity, (local, vel, accel, gravity, drag)) in world
+        for (_entity, (local, vel, accel, gravity, drag, held)) in world
             .query_mut::<(
                 &mut LocalTransform,
                 &mut Velocity,
                 Option<&Acceleration>,
                 Option<&GravityAffected>,
                 Option<&Drag>,
+                Option<&Held>,
             )>()
         {
+            if held.is_some() {
+                continue;
+            }
             if gravity.is_some() {
                 vel.0 += GRAVITY * PHYSICS_DT;
             }

--- a/src/systems/raycast.rs
+++ b/src/systems/raycast.rs
@@ -1,0 +1,99 @@
+use glam::Vec3;
+use hecs::{Entity, World};
+
+use crate::components::{Collider, GlobalTransform, Grabbable};
+
+#[allow(dead_code)]
+pub struct RaycastHit {
+    pub entity: Entity,
+    pub distance: f32,
+    pub point: Vec3,
+}
+
+/// Cast a ray against all Grabbable entities, returning the nearest hit within max_distance.
+pub fn raycast_grabbable(
+    world: &World,
+    origin: Vec3,
+    direction: Vec3,
+    max_distance: f32,
+) -> Option<RaycastHit> {
+    let dir = direction.normalize();
+    let mut best: Option<RaycastHit> = None;
+
+    for (entity, (_grabbable, global, collider)) in
+        world.query::<(&Grabbable, &GlobalTransform, &Collider)>().iter()
+    {
+        let center = Vec3::new(global.0.w_axis.x, global.0.w_axis.y, global.0.w_axis.z);
+
+        let t = match collider {
+            Collider::Sphere { radius } => ray_sphere_intersection(origin, dir, center, *radius),
+            Collider::Capsule { radius, height } => {
+                ray_capsule_intersection(origin, dir, center, *radius, *height)
+            }
+            Collider::Plane { .. } => None,
+        };
+
+        if let Some(t) = t {
+            if t > 0.0 && t <= max_distance {
+                let is_closer = best.as_ref().map_or(true, |b| t < b.distance);
+                if is_closer {
+                    best = Some(RaycastHit {
+                        entity,
+                        distance: t,
+                        point: origin + dir * t,
+                    });
+                }
+            }
+        }
+    }
+
+    best
+}
+
+fn ray_sphere_intersection(origin: Vec3, dir: Vec3, center: Vec3, radius: f32) -> Option<f32> {
+    let oc = origin - center;
+    let a = dir.dot(dir);
+    let b = 2.0 * oc.dot(dir);
+    let c = oc.dot(oc) - radius * radius;
+    let discriminant = b * b - 4.0 * a * c;
+
+    if discriminant < 0.0 {
+        return None;
+    }
+
+    let sqrt_d = discriminant.sqrt();
+    let t1 = (-b - sqrt_d) / (2.0 * a);
+    let t2 = (-b + sqrt_d) / (2.0 * a);
+
+    if t1 > 0.0 {
+        Some(t1)
+    } else if t2 > 0.0 {
+        Some(t2)
+    } else {
+        None
+    }
+}
+
+fn ray_capsule_intersection(
+    origin: Vec3,
+    dir: Vec3,
+    center: Vec3,
+    radius: f32,
+    height: f32,
+) -> Option<f32> {
+    let half_h = height * 0.5;
+    let top = center + Vec3::Y * half_h;
+    let bottom = center - Vec3::Y * half_h;
+
+    // Test both hemisphere centers as spheres (approximation suitable for grab detection)
+    let t_top = ray_sphere_intersection(origin, dir, top, radius);
+    let t_bottom = ray_sphere_intersection(origin, dir, bottom, radius);
+    // Also test center sphere for the cylindrical body
+    let t_center = ray_sphere_intersection(origin, dir, center, radius);
+
+    [t_top, t_bottom, t_center]
+        .iter()
+        .filter_map(|t| *t)
+        .filter(|t| *t > 0.0)
+        .reduce(f32::min)
+}


### PR DESCRIPTION
## Summary
- Implement grab/throw system: Alt+RightClick to grab, left-click hold to wind up, release to throw, release Alt or RightClick to drop
- Add sphere-based raycasting against Grabbable entities for target selection
- Re-parent held objects under the player entity to eliminate jitter, with counter-rotation to preserve world-space orientation
- Rotate player entity to match camera yaw so arms and held objects face correctly
- Hide player capsule and arms in first-person view (Z toggle) while keeping physics/collision active
- Add mouse button tracking to InputState; skip held entities from physics and collision

## Test plan
- [x] Alt+RightClick on red sphere — sphere lerps to position in front of player
- [x] Move camera while holding — sphere stays relative to player body, no jitter
- [x] Release just Alt (keep right held) — sphere drops
- [x] Release just RightClick (keep Alt held) — sphere drops
- [x] Grab, hold left-click to wind up, release — sphere thrown in camera direction
- [x] Held object maintains its original orientation while being carried
- [x] Toggle first/third person (Z key) — capsule and arms hidden in first person, visible in third
- [x] Physics and collision still work on player while hidden in first person