### PR TITLE
Fix grabbed object rotation to track with camera

### DIFF
--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -129,7 +129,7 @@ pub struct GrabState {
     pub held_entity: Option<Entity>,
     pub wind_up_time: f32,
     pub is_winding: bool,
-    /// World-space rotation of the held entity at grab time (preserved while held).
+    /// Player-local rotation of the held entity (rotates with player via parenting).
     pub held_rotation: Quat,
 }
 


### PR DESCRIPTION
## Summary
- Store player-local rotation in `GrabState` instead of world-space rotation, so held objects rotate naturally with the player via parent-child transform hierarchy
- Restore correct world rotation (extracted from `GlobalTransform`) on drop/throw instead of resetting to identity
- Extract shared world-transform logic into `extract_world_transform()` helper

## Test plan
- [x] Grab red sphere (Alt+RightClick), turn camera — sphere should rotate with you
- [x] Drop (release Alt or RightClick) — sphere keeps its current world rotation
- [x] Grab, wind up (hold LMB), throw (release LMB) — sphere keeps rotation on release