### PR TITLE
Add held object momentum and pitch tracking

### DIFF
--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -131,6 +131,10 @@ pub struct GrabState {
     pub is_winding: bool,
     /// Player-local rotation of the held entity (rotates with player via parenting).
     pub held_rotation: Quat,
+    /// Previous frame's world position of the held entity (for velocity tracking).
+    pub prev_world_pos: Vec3,
+    /// Smoothed world-space velocity of the held entity.
+    pub held_velocity: Vec3,
 }
 
 impl GrabState {
@@ -140,6 +144,8 @@ impl GrabState {
             wind_up_time: 0.0,
             is_winding: false,
             held_rotation: Quat::IDENTITY,
+            prev_world_pos: Vec3::ZERO,
+            held_velocity: Vec3::ZERO,
         }
     }
 }


### PR DESCRIPTION
## Summary
- Track world-space velocity of held objects using exponential smoothing, applied on drop (full momentum) and throw (damped addition to throw force)
- Held objects now pitch-rotate to match the camera angle with smooth slerp interpolation
- First-person toggle (Z) no longer hides grabbed objects — entities with the `Held` marker are skipped

## Test plan
- [x] Grab an object, move/strafe around, then release — it should carry your movement momentum
- [x] Grab an object, wind up and throw while strafing — throw direction should include lateral momentum
- [x] Look up/down while holding an object — it should smoothly tilt to follow camera pitch
- [x] Toggle first person (Z) while holding an object — held object should remain visible
- [x] Toggle back to third person — player body reappears normally