### PR TITLE
Add sword mesh, sheathe/wield toggle, and camera/grab improvements

### DIFF
--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -149,3 +149,19 @@ impl GrabState {
         }
     }
 }
+
+/// Whether the sword is sheathed at the hip or wielded in hand.
+#[derive(Clone, Copy, PartialEq)]
+pub enum SwordPosition {
+    Sheathed,
+    Wielded,
+}
+
+/// State for the sword entity, attached to the sword child of the player.
+pub struct SwordState {
+    pub position: SwordPosition,
+    pub sheathed_pos: Vec3,
+    pub sheathed_rot: Quat,
+    pub wielded_pos: Vec3,
+    pub wielded_rot: Quat,
+}

--- a/src/renderer/mesh.rs
+++ b/src/renderer/mesh.rs
@@ -211,6 +211,232 @@ pub fn create_capsule(radius: f32, height: f32, sectors: u32, stacks: u32) -> Me
     upload_mesh(&vertices, &indices)
 }
 
+#[allow(dead_code)]
+pub fn create_box(width: f32, height: f32, depth: f32) -> Mesh {
+    let hw = width * 0.5;
+    let hh = height * 0.5;
+    let hd = depth * 0.5;
+
+    #[rustfmt::skip]
+    let vertices: Vec<f32> = vec![
+        // Front face (+Z)
+        -hw, -hh,  hd,  0.0,  0.0,  1.0,
+         hw, -hh,  hd,  0.0,  0.0,  1.0,
+         hw,  hh,  hd,  0.0,  0.0,  1.0,
+        -hw,  hh,  hd,  0.0,  0.0,  1.0,
+        // Back face (-Z)
+         hw, -hh, -hd,  0.0,  0.0, -1.0,
+        -hw, -hh, -hd,  0.0,  0.0, -1.0,
+        -hw,  hh, -hd,  0.0,  0.0, -1.0,
+         hw,  hh, -hd,  0.0,  0.0, -1.0,
+        // Top face (+Y)
+        -hw,  hh,  hd,  0.0,  1.0,  0.0,
+         hw,  hh,  hd,  0.0,  1.0,  0.0,
+         hw,  hh, -hd,  0.0,  1.0,  0.0,
+        -hw,  hh, -hd,  0.0,  1.0,  0.0,
+        // Bottom face (-Y)
+        -hw, -hh, -hd,  0.0, -1.0,  0.0,
+         hw, -hh, -hd,  0.0, -1.0,  0.0,
+         hw, -hh,  hd,  0.0, -1.0,  0.0,
+        -hw, -hh,  hd,  0.0, -1.0,  0.0,
+        // Right face (+X)
+         hw, -hh,  hd,  1.0,  0.0,  0.0,
+         hw, -hh, -hd,  1.0,  0.0,  0.0,
+         hw,  hh, -hd,  1.0,  0.0,  0.0,
+         hw,  hh,  hd,  1.0,  0.0,  0.0,
+        // Left face (-X)
+        -hw, -hh, -hd, -1.0,  0.0,  0.0,
+        -hw, -hh,  hd, -1.0,  0.0,  0.0,
+        -hw,  hh,  hd, -1.0,  0.0,  0.0,
+        -hw,  hh, -hd, -1.0,  0.0,  0.0,
+    ];
+
+    let mut indices = Vec::new();
+    for face in 0..6u32 {
+        let base = face * 4;
+        indices.extend_from_slice(&[base, base + 1, base + 2, base, base + 2, base + 3]);
+    }
+
+    upload_mesh(&vertices, &indices)
+}
+
+#[allow(dead_code)]
+pub fn create_cylinder(radius: f32, height: f32, segments: u32) -> Mesh {
+    let mut vertices = Vec::new();
+    let mut indices = Vec::new();
+    let half_h = height * 0.5;
+
+    // Side vertices: two rings (top and bottom) with outward normals
+    for i in 0..=segments {
+        let angle = 2.0 * PI * (i as f32) / (segments as f32);
+        let nx = angle.cos();
+        let nz = angle.sin();
+        let x = radius * nx;
+        let z = radius * nz;
+
+        // Bottom ring
+        vertices.extend_from_slice(&[x, -half_h, z, nx, 0.0, nz]);
+        // Top ring
+        vertices.extend_from_slice(&[x, half_h, z, nx, 0.0, nz]);
+    }
+
+    // Side indices
+    for i in 0..segments {
+        let bot = i * 2;
+        let top = bot + 1;
+        let next_bot = bot + 2;
+        let next_top = bot + 3;
+        indices.extend_from_slice(&[bot, next_bot, top, top, next_bot, next_top]);
+    }
+
+    // Top cap
+    let top_center = vertices.len() as u32 / 6;
+    vertices.extend_from_slice(&[0.0, half_h, 0.0, 0.0, 1.0, 0.0]);
+    let top_ring_start = vertices.len() as u32 / 6;
+    for i in 0..=segments {
+        let angle = 2.0 * PI * (i as f32) / (segments as f32);
+        let x = radius * angle.cos();
+        let z = radius * angle.sin();
+        vertices.extend_from_slice(&[x, half_h, z, 0.0, 1.0, 0.0]);
+    }
+    for i in 0..segments {
+        indices.extend_from_slice(&[top_center, top_ring_start + i, top_ring_start + i + 1]);
+    }
+
+    // Bottom cap
+    let bot_center = vertices.len() as u32 / 6;
+    vertices.extend_from_slice(&[0.0, -half_h, 0.0, 0.0, -1.0, 0.0]);
+    let bot_ring_start = vertices.len() as u32 / 6;
+    for i in 0..=segments {
+        let angle = 2.0 * PI * (i as f32) / (segments as f32);
+        let x = radius * angle.cos();
+        let z = radius * angle.sin();
+        vertices.extend_from_slice(&[x, -half_h, z, 0.0, -1.0, 0.0]);
+    }
+    for i in 0..segments {
+        indices.extend_from_slice(&[bot_center, bot_ring_start + i + 1, bot_ring_start + i]);
+    }
+
+    upload_mesh(&vertices, &indices)
+}
+
+/// Create a sword mesh composed of blade (box), crossguard (box), and handle (cylinder).
+/// Origin is at the grip point (top of handle / base of blade).
+pub fn create_sword() -> Mesh {
+    let mut vertices = Vec::new();
+    let mut indices = Vec::new();
+
+    // Helper: append a box at an offset position, return vertex count added
+    let add_box = |verts: &mut Vec<f32>, idxs: &mut Vec<u32>,
+                       w: f32, h: f32, d: f32, offset_y: f32| {
+        let base = verts.len() as u32 / 6;
+        let hw = w * 0.5;
+        let hh = h * 0.5;
+        let hd = d * 0.5;
+        let oy = offset_y;
+
+        #[rustfmt::skip]
+        let box_verts: [f32; 144] = [
+            // Front (+Z)
+            -hw, -hh + oy,  hd,  0.0,  0.0,  1.0,
+             hw, -hh + oy,  hd,  0.0,  0.0,  1.0,
+             hw,  hh + oy,  hd,  0.0,  0.0,  1.0,
+            -hw,  hh + oy,  hd,  0.0,  0.0,  1.0,
+            // Back (-Z)
+             hw, -hh + oy, -hd,  0.0,  0.0, -1.0,
+            -hw, -hh + oy, -hd,  0.0,  0.0, -1.0,
+            -hw,  hh + oy, -hd,  0.0,  0.0, -1.0,
+             hw,  hh + oy, -hd,  0.0,  0.0, -1.0,
+            // Top (+Y)
+            -hw,  hh + oy,  hd,  0.0,  1.0,  0.0,
+             hw,  hh + oy,  hd,  0.0,  1.0,  0.0,
+             hw,  hh + oy, -hd,  0.0,  1.0,  0.0,
+            -hw,  hh + oy, -hd,  0.0,  1.0,  0.0,
+            // Bottom (-Y)
+            -hw, -hh + oy, -hd,  0.0, -1.0,  0.0,
+             hw, -hh + oy, -hd,  0.0, -1.0,  0.0,
+             hw, -hh + oy,  hd,  0.0, -1.0,  0.0,
+            -hw, -hh + oy,  hd,  0.0, -1.0,  0.0,
+            // Right (+X)
+             hw, -hh + oy,  hd,  1.0,  0.0,  0.0,
+             hw, -hh + oy, -hd,  1.0,  0.0,  0.0,
+             hw,  hh + oy, -hd,  1.0,  0.0,  0.0,
+             hw,  hh + oy,  hd,  1.0,  0.0,  0.0,
+            // Left (-X)
+            -hw, -hh + oy, -hd, -1.0,  0.0,  0.0,
+            -hw, -hh + oy,  hd, -1.0,  0.0,  0.0,
+            -hw,  hh + oy,  hd, -1.0,  0.0,  0.0,
+            -hw,  hh + oy, -hd, -1.0,  0.0,  0.0,
+        ];
+
+        verts.extend_from_slice(&box_verts);
+        for face in 0..6u32 {
+            let b = base + face * 4;
+            idxs.extend_from_slice(&[b, b + 1, b + 2, b, b + 2, b + 3]);
+        }
+    };
+
+    // Helper: append a cylinder at an offset position
+    let add_cylinder = |verts: &mut Vec<f32>, idxs: &mut Vec<u32>,
+                        radius: f32, height: f32, segments: u32, offset_y: f32| {
+        let base = verts.len() as u32 / 6;
+        let half_h = height * 0.5;
+
+        // Side rings
+        for i in 0..=segments {
+            let angle = 2.0 * PI * (i as f32) / (segments as f32);
+            let nx = angle.cos();
+            let nz = angle.sin();
+            let x = radius * nx;
+            let z = radius * nz;
+            verts.extend_from_slice(&[x, -half_h + offset_y, z, nx, 0.0, nz]);
+            verts.extend_from_slice(&[x, half_h + offset_y, z, nx, 0.0, nz]);
+        }
+        for i in 0..segments {
+            let bot = base + i * 2;
+            let top = bot + 1;
+            let next_bot = bot + 2;
+            let next_top = bot + 3;
+            idxs.extend_from_slice(&[bot, next_bot, top, top, next_bot, next_top]);
+        }
+
+        // Top cap
+        let tc = verts.len() as u32 / 6;
+        verts.extend_from_slice(&[0.0, half_h + offset_y, 0.0, 0.0, 1.0, 0.0]);
+        let tr = verts.len() as u32 / 6;
+        for i in 0..=segments {
+            let angle = 2.0 * PI * (i as f32) / (segments as f32);
+            verts.extend_from_slice(&[radius * angle.cos(), half_h + offset_y, radius * angle.sin(), 0.0, 1.0, 0.0]);
+        }
+        for i in 0..segments {
+            idxs.extend_from_slice(&[tc, tr + i, tr + i + 1]);
+        }
+
+        // Bottom cap
+        let bc = verts.len() as u32 / 6;
+        verts.extend_from_slice(&[0.0, -half_h + offset_y, 0.0, 0.0, -1.0, 0.0]);
+        let br = verts.len() as u32 / 6;
+        for i in 0..=segments {
+            let angle = 2.0 * PI * (i as f32) / (segments as f32);
+            verts.extend_from_slice(&[radius * angle.cos(), -half_h + offset_y, radius * angle.sin(), 0.0, -1.0, 0.0]);
+        }
+        for i in 0..segments {
+            idxs.extend_from_slice(&[bc, br + i + 1, br + i]);
+        }
+    };
+
+    // Handle: cylinder, radius 0.02, height 0.15, centered below origin
+    add_cylinder(&mut vertices, &mut indices, 0.02, 0.15, 8, -0.075);
+
+    // Crossguard: wide short box at origin (grip point)
+    add_box(&mut vertices, &mut indices, 0.2, 0.03, 0.03, 0.0);
+
+    // Blade: tall thin box above crossguard
+    add_box(&mut vertices, &mut indices, 0.05, 0.8, 0.02, 0.415);
+
+    upload_mesh(&vertices, &indices)
+}
+
 pub fn create_ground_plane(half_extent: f32) -> Mesh {
     let h = half_extent;
     #[rustfmt::skip]


### PR DESCRIPTION
## Summary
- Programmatic sword mesh composed of blade (box), crossguard (box), and handle (cylinder) with reusable `create_box()` and `create_cylinder()` mesh generators
- Sword attached as child of player entity at the hip; F key toggles between sheathed and wielded positions
- Camera perspective cycles through 3 states with Z: third-person back, third-person front (face view), and first-person
- Sword stays visible in all perspective modes (not hidden in first person)
- Grab raycast now originates from player's chest instead of the camera position
- Drop velocity strongly dampened (5% of tracked velocity) to prevent objects flying on release

Closes #6

## Test plan
- [x] Verify sword renders on player's hip with correct tilt
- [x] Press F to toggle between sheathed and wielded positions
- [x] Press Z to cycle: back view → front view → first person → back view
- [x] Confirm sword stays visible in first-person mode
- [x] Alt+RightClick grab works from chest-level raycast
- [x] Dropping a held object no longer flings it with excess velocity
- [x] Throwing still applies full force correctly