### PR TITLE
Fix entity jitter: add physics interpolation (#19)

### DIFF
--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -75,6 +75,7 @@ pub enum Collider {
     Sphere { radius: f32 },
     Capsule { radius: f32, height: f32 },
     Plane { normal: Vec3, offset: f32 },
+    Box { half_extents: Vec3 },
 }
 
 /// Marker: entity is immovable (infinite mass for collision response).
@@ -117,6 +118,16 @@ pub struct Checkerboard(pub Vec3);
 
 /// Marker: entity is hidden from rendering but still participates in physics/collision.
 pub struct Hidden;
+
+/// Previous physics-step position, stored for render interpolation.
+/// Updated at the start of each physics step; used by transform propagation
+/// to lerp between prev and current position by the accumulator alpha.
+pub struct PreviousPosition(pub Vec3);
+
+/// Marker: entities with the same owner Entity skip collision with each other.
+/// Attach to all body parts of a character (torso, head, limbs) with the root entity as owner.
+#[derive(Clone, Copy)]
+pub struct NoSelfCollision(pub Entity);
 
 /// Marker: entity can be grabbed by the player.
 pub struct Grabbable;
@@ -164,6 +175,21 @@ pub struct SwordState {
     pub sheathed_rot: Quat,
     pub wielded_pos: Vec3,
     pub wielded_rot: Quat,
+}
+
+/// Tracks the limb entities that make up the player's character body.
+/// Attached to the player entity for direct access to limbs.
+pub struct CharacterBody {
+    pub head: Entity,
+    pub left_upper_arm: Entity,
+    pub left_forearm: Entity,
+    pub right_upper_arm: Entity,
+    pub right_forearm: Entity,
+    pub left_upper_leg: Entity,
+    pub left_lower_leg: Entity,
+    pub right_upper_leg: Entity,
+    pub right_lower_leg: Entity,
+    pub sword: Entity,
 }
 
 /// Directional light component (sun-like). Casts shadows via shadow mapping.

--- a/src/systems/transform.rs
+++ b/src/systems/transform.rs
@@ -3,21 +3,37 @@ use std::collections::VecDeque;
 use glam::Mat4;
 use hecs::{Entity, World};
 
-use crate::components::{Children, GlobalTransform, LocalTransform, Parent};
+use crate::components::{Children, GlobalTransform, LocalTransform, Parent, PreviousPosition};
 
 /// Propagates LocalTransform down the hierarchy via BFS.
 /// Roots (entities with LocalTransform but no Parent) compute GlobalTransform
 /// from their own LocalTransform. Children inherit parent's GlobalTransform
 /// multiplied by their own LocalTransform.
-pub fn transform_propagation_system(world: &mut World) {
+///
+/// `alpha` is the render interpolation factor (0..1): how far into the current
+/// physics step this render frame falls. Root physics entities with a
+/// `PreviousPosition` component have their translation lerped between the
+/// previous and current physics position, eliminating fixed-timestep jitter.
+pub fn transform_propagation_system(world: &mut World, alpha: f32) {
     let mut queue: VecDeque<(Entity, Mat4)> = VecDeque::new();
 
-    // Phase 1: update roots and seed BFS with their children
+    // Phase 1: update roots and seed BFS with their children.
+    // Query LocalTransform + optional PreviousPosition together so the borrow
+    // is released before we write GlobalTransform.
     let roots: Vec<(Entity, Mat4)> = world
-        .query::<&LocalTransform>()
+        .query::<(&LocalTransform, Option<&PreviousPosition>)>()
         .without::<&Parent>()
         .iter()
-        .map(|(entity, local)| (entity, local.matrix()))
+        .map(|(entity, (local, prev))| {
+            let mat = if let Some(prev) = prev {
+                // Lerp translation between previous and current physics state.
+                let interp_pos = prev.0.lerp(local.position, alpha);
+                Mat4::from_scale_rotation_translation(local.scale, local.rotation, interp_pos)
+            } else {
+                local.matrix()
+            };
+            (entity, mat)
+        })
         .collect();
 
     for (entity, global_mat) in &roots {


### PR DESCRIPTION
## Summary

- Added `PreviousPosition` component — snapshotted at the start of each fixed physics step for every dynamic entity
- `physics_system` now returns `(Vec<CollisionEvent>, f32)` where the `f32` is `alpha = accumulator / PHYSICS_DT`, the render frame's position within the current physics step
- `transform_propagation_system` accepts `alpha` and lerps root entity translations between their previous and current physics positions before writing `GlobalTransform`
- Camera follow also uses the interpolated player position, so the view tracks the entity without any stutter

## Result

It looks **beautiful** — absolutely no jittering, even during simultaneous WASD movement and fast mouse rotation. Entities glide smoothly at any framerate against the fixed 60Hz physics tick.

## Test plan

- [x] Run the game and move + rotate camera simultaneously — verify no jitter on player or other dynamic entities
- [x] Verify the red sphere bounces smoothly
- [ ] Verify pause/resume works correctly (alpha held at 1.0 while paused)
- [ ] Verify jumping and grounded detection still work normally

Closes #19